### PR TITLE
Fix imports for django 4 and django-recaptcha 3

### DIFF
--- a/contact_form/forms.py
+++ b/contact_form/forms.py
@@ -6,7 +6,7 @@ a web interface.
 from django import forms
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.core.mail import send_mail
 from django.template import loader
 
@@ -191,7 +191,6 @@ class ReCaptchaContactForm(ContactForm):
     import os
     from captcha.fields import ReCaptchaField
     captcha = ReCaptchaField(
-      attrs={'lang': getattr(settings, 'RECAPTCHA_LANG', None),
-             'RECAPTCHA_PUBLIC_KEY': os.getenv('PYTHON_RECAPTCHA_PUBLIC_KEY'),
-             'RECAPTCHA_PRIVATE_KEY': os.getenv('PYTHON_RECAPTCHA_PRIVATE_KEY')
-             })
+      os.getenv('PYTHON_RECAPTCHA_PUBLIC_KEY'),
+      os.getenv('PYTHON_RECAPTCHA_PRIVATE_KEY')
+    )

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(name='django-contact-form-recaptcha',
                    'Programming Language :: Python :: 3.6',
                    'Topic :: Utilities'],
       install_requires=[
-          'Django>=1.11',
-          'django-recaptcha',
+          'Django>=4.1.5',
+          'django-recaptcha>=3.0.0',
       ],
       extras_require={
           'akismet': ['akismet'],


### PR DESCRIPTION
Fix imports for Django 4.
Fix args for django-recaptcha 3.

Working dependencies:
django-recaptcha==3.0.0
django==4.1.5

I have not tested lower versions.